### PR TITLE
Update update-range.js

### DIFF
--- a/src/update-range.js
+++ b/src/update-range.js
@@ -17,7 +17,7 @@ const updateRange = (range, latest, versions) => {
   const updatedRange = `${match[1] || ''}${latest}`;
 
   // Validate that the new range contains only the latest version.
-  for (let i = 0, len = versions.length; i < len; i++) {
+  for (var i = 0, len = versions.length; i < len; i++) {
     const version = versions[i];
 
     if (semver.satisfies(version, updatedRange) && version !== latest) {


### PR DESCRIPTION
small fix to allow for running without transpile in node 4.3

(currently fails with `SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`)